### PR TITLE
RabbitMQ 다중 노드 클러스터 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 rabbitmq/data/
+rabbitmq-cluster/data/
 .env

--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -21,6 +21,7 @@ services:
       - ./haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
     ports:
       - "5672:5672"
+      - "${EXTERNAL_RABBITMQ_MANAGEMENT_PORT:-15672}:15672"
     networks:
       elk-net:
         aliases:
@@ -47,8 +48,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
-    ports:
-      - "${EXTERNAL_RABBITMQ_MANAGEMENT_PORT:-15672}:15672"
     networks:
       elk-net:
         aliases:
@@ -90,6 +89,7 @@ services:
       elk-net:
         aliases:
           - rabbit2
+          
   rabbit3:
     build:
       context: ./rabbitmq-cluster

--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -22,7 +22,9 @@ services:
     ports:
       - "5672:5672"
     networks:
-      - elk-net
+      elk-net:
+        aliases:
+          - haproxy
 
   # ─ RabbitMQ 3-node Quorum cluster ──────────────────────────
   rabbit1:

--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -1,38 +1,21 @@
-version: "2.4"
+version: "3.9"
 services:
   haproxy:
     image: haproxy:2.4
-    container_name: haproxy
-    depends_on:
-      rabbit1:
-        condition: service_healthy
-      rabbit2:
-        condition: service_healthy
-      rabbit3:
-        condition: service_healthy
+    user: haproxy
+    entrypoint: >
+      sh -c "
+        exec haproxy -f /usr/local/etc/haproxy/haproxy.cfg
+      "
+    tmpfs:
+      - /tmp/haproxy:mode=1777,size=16m   # ← 핵심
     volumes:
+      # (★) 호스트의 cfg → 컨테이너 cfg
       - ./haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
-      - ./haproxy/queue_ports.map:/etc/haproxy/queue_ports.map:ro
-      - ./haproxy/port_map.map:/etc/haproxy/port_map.map
-      - /var/run/haproxy.sock:/var/run/haproxy.sock
     ports:
-      - "50000-50100:50000-50100"
+      - "5672:5672"
     networks:
       - elk-net
-
-  map-updater:
-    build:
-      context: ./haproxy
-      dockerfile: Dockerfile.map
-    container_name: haproxy-map-updater
-    depends_on:
-      haproxy:
-        condition: service_started
-    volumes:
-      - ./haproxy/queue_ports.map:/etc/haproxy/queue_ports.map:ro
-      - ./haproxy/port_map.map:/etc/haproxy/port_map.map
-      - /var/run/haproxy.sock:/var/run/haproxy.sock
-    entrypoint: ["/update_map.sh"]
 
   # ─ RabbitMQ 3-node Quorum cluster ──────────────────────────
   rabbit1:
@@ -47,6 +30,7 @@ services:
     volumes:
       - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
       - ./rabbitmq/data/rabbit1:/var/lib/rabbitmq/mnesia
+      - ./rabbitmq/definitions.json:/etc/rabbitmq/definitions.json:ro
     healthcheck:
       test: ["CMD", "rabbitmqctl", "status"]
       interval: 10s
@@ -54,8 +38,7 @@ services:
       retries: 5
       start_period: 30s
     ports:
-      - "${EXTERNAL_HAPROXY_PORT}:5672"
-      - "${EXTERNAL_RABBITMQ_MANAGEMENT_PORT}:15672"
+      - "${EXTERNAL_RABBITMQ_MANAGEMENT_PORT:-15672}:15672"
     networks:
       elk-net:
         aliases:
@@ -81,6 +64,8 @@ services:
     volumes:
       - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
       - ./rabbitmq/data/rabbit2:/var/lib/rabbitmq/mnesia
+      - ./rabbitmq/definitions.json:/etc/rabbitmq/definitions.json:ro
+      
     entrypoint: >
       bash -c "
         rabbitmq-server -detached &&
@@ -115,6 +100,7 @@ services:
     volumes:
       - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
       - ./rabbitmq/data/rabbit3:/var/lib/rabbitmq/mnesia
+      - ./rabbitmq/definitions.json:/etc/rabbitmq/definitions.json:ro
     entrypoint: >
       bash -c "
         rabbitmq-server -detached &&
@@ -223,7 +209,7 @@ services:
         # 1) ES 준비 대기
         /usr/local/bin/wait-for-it.sh elasticsearch:9200 --strict --timeout=120 &&
         # 2) RabbitMQ 준비 대기
-        /usr/local/bin/wait-for-it.sh rabbitmq:5672 --strict --timeout=60 &&
+        /usr/local/bin/wait-for-it.sh haproxy:5672 --strict --timeout=60 &&
         # 3) 준비되면 Logstash 진짜 진입점 실행
         exec /usr/local/bin/docker-entrypoint
       "
@@ -246,7 +232,7 @@ services:
         # 1) ES 준비 대기
         /usr/local/bin/wait-for-it.sh elasticsearch:9200 --strict --timeout=120 &&
         # 2) RabbitMQ 준비 대기
-        /usr/local/bin/wait-for-it.sh rabbitmq:5672 --strict --timeout=60 &&
+        /usr/local/bin/wait-for-it.sh haproxy:5672 --strict --timeout=60 &&
         # 3) 준비되면 Logstash 진짜 진입점 실행
         exec /usr/local/bin/docker-entrypoint
       "
@@ -269,7 +255,7 @@ services:
         # 1) ES 준비 대기
         /usr/local/bin/wait-for-it.sh elasticsearch:9200 --strict --timeout=120 &&
         # 2) RabbitMQ 준비 대기
-        /usr/local/bin/wait-for-it.sh rabbitmq:5672 --strict --timeout=60 &&
+        /usr/local/bin/wait-for-it.sh haproxy:5672 --strict --timeout=60 &&
         # 3) 준비되면 Logstash 진짜 진입점 실행
         exec /usr/local/bin/docker-entrypoint
       "

--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -39,7 +39,7 @@ services:
       - ./rabbitmq/data/rabbit1:/var/lib/rabbitmq/mnesia
       - ./rabbitmq/definitions.json:/etc/rabbitmq/definitions.json:ro
     healthcheck:
-      test: ["CMD", "rabbitmqctl", "status"]
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -58,7 +58,7 @@ services:
       rabbit1:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "rabbitmqctl", "status"]
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -94,7 +94,7 @@ services:
       rabbit1:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "rabbitmqctl", "status"]
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -240,7 +240,7 @@ services:
       - rabbit3
       - es-init
     volumes:
-      - ./logstash/pipeline1:/usr/share/logstash/pipeline
+      - ./logstash/pipeline2:/usr/share/logstash/pipeline
       - ./wait-for-it.sh:/usr/local/bin/wait-for-it.sh
     entrypoint: >
       bash -c "
@@ -263,7 +263,7 @@ services:
       - rabbit3
       - es-init
     volumes:
-      - ./logstash/pipeline1:/usr/share/logstash/pipeline
+      - ./logstash/pipeline3:/usr/share/logstash/pipeline
       - ./wait-for-it.sh:/usr/local/bin/wait-for-it.sh
     entrypoint: >
       bash -c "

--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -41,7 +41,6 @@ services:
     volumes:
       - ./rabbitmq-cluster/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
       - ./rabbitmq-cluster/data/rabbit1:/var/lib/rabbitmq/mnesia
-      - ./rabbitmq-cluster/definitions.json:/etc/rabbitmq/definitions.json:ro
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 10s
@@ -77,7 +76,6 @@ services:
     volumes:
       - ./rabbitmq-cluster/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
       - ./rabbitmq-cluster/data/rabbit2:/var/lib/rabbitmq/mnesia
-      - ./rabbitmq-cluster/definitions.json:/etc/rabbitmq/definitions.json:ro
       
     entrypoint: >
       bash -c "
@@ -115,7 +113,6 @@ services:
     volumes:
       - ./rabbitmq-cluster/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
       - ./rabbitmq-cluster/data/rabbit3:/var/lib/rabbitmq/mnesia
-      - ./rabbitmq-cluster/definitions.json:/etc/rabbitmq/definitions.json:ro
     entrypoint: >
       bash -c "
         rabbitmq-server -detached &&
@@ -140,22 +137,37 @@ services:
       rabbit3:
         condition: service_healthy
     volumes:
-      - ./rabbitmq/definitions.json:/definitions.json:ro
+      - ./rabbitmq-cluster/definitions.json:/definitions.json:ro
     entrypoint: >
       sh -c '
-        echo "$(date) waiting for RabbitMQ cluster…";
-        until curl -s -u "${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}" \
-            http://rabbit1:15672/api/nodes | grep -q rabbit@rabbit3; do
-          sleep 5;
-        done;
-        echo "$(date) importing definitions…";
-        curl -u "${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}" \
-             -H "Content-Type: application/json" \
-             -X POST \
-             --data-binary @/definitions.json \
-             http://rabbit1:15672/api/definitions;
-        echo "$(date) done.";
+        set -eu
+        USER=$${RABBITMQ_DEFAULT_USER:-guest}
+        PASS=$${RABBITMQ_DEFAULT_PASS:-guest}
+        HOST="rabbit1:15672"
+
+        echo "$$(date) ⏳  waiting for rabbit1/2/3 to join…"
+        while :; do
+          json=$$(curl -s -u "$$USER:$$PASS" "http://$$HOST/api/nodes" || true)
+
+          echo "$$json" | grep -q "\"name\":\"rabbit@rabbit1\"" || { sleep 5; continue; }
+          echo "$$json" | grep -q "\"name\":\"rabbit@rabbit2\"" || { sleep 5; continue; }
+          echo "$$json" | grep -q "\"name\":\"rabbit@rabbit3\"" || { sleep 5; continue; }
+
+          break
+        done
+
+        echo "Waiting for 60 seconds...."
+        sleep 60
+
+        echo "$$(date) ✅  cluster ready. importing definitions…"
+        curl -sS -u "$$USER:$$PASS" -H "Content-Type: application/json" \
+            -X POST --data-binary @/definitions.json \
+            "http://$$HOST/api/definitions"
+        echo "$$(date) 🎉  done."
       '
+    networks:
+      - elk-net
+
   # ─ Elasticsearch ───────────────────────────────────────────
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4

--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -28,7 +28,9 @@ services:
 
   # ─ RabbitMQ 3-node Quorum cluster ──────────────────────────
   rabbit1:
-    image: heidiks/rabbitmq-delayed-message-exchange:3.12.2-management
+    build:
+      context: ./rabbitmq-cluster
+      dockerfile: Dockerfile
     hostname: rabbit1
     container_name: rabbit1
     environment:
@@ -37,9 +39,9 @@ services:
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
       - RABBITMQ_NODENAME=${RABBITMQ_NODENAME_PREFIX}rabbit1
     volumes:
-      - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
-      - ./rabbitmq/data/rabbit1:/var/lib/rabbitmq/mnesia
-      - ./rabbitmq/definitions.json:/etc/rabbitmq/definitions.json:ro
+      - ./rabbitmq-cluster/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
+      - ./rabbitmq-cluster/data/rabbit1:/var/lib/rabbitmq/mnesia
+      - ./rabbitmq-cluster/definitions.json:/etc/rabbitmq/definitions.json:ro
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 10s
@@ -53,7 +55,9 @@ services:
         aliases:
           - rabbit1
   rabbit2:
-    image: heidiks/rabbitmq-delayed-message-exchange:3.12.2-management
+    build:
+      context: ./rabbitmq-cluster
+      dockerfile: Dockerfile
     hostname: rabbit2
     container_name: rabbit2
     depends_on:
@@ -71,9 +75,9 @@ services:
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
       - RABBITMQ_NODENAME=${RABBITMQ_NODENAME_PREFIX}rabbit2
     volumes:
-      - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
-      - ./rabbitmq/data/rabbit2:/var/lib/rabbitmq/mnesia
-      - ./rabbitmq/definitions.json:/etc/rabbitmq/definitions.json:ro
+      - ./rabbitmq-cluster/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
+      - ./rabbitmq-cluster/data/rabbit2:/var/lib/rabbitmq/mnesia
+      - ./rabbitmq-cluster/definitions.json:/etc/rabbitmq/definitions.json:ro
       
     entrypoint: >
       bash -c "
@@ -89,7 +93,9 @@ services:
         aliases:
           - rabbit2
   rabbit3:
-    image: heidiks/rabbitmq-delayed-message-exchange:3.12.2-management
+    build:
+      context: ./rabbitmq-cluster
+      dockerfile: Dockerfile
     hostname: rabbit3
     container_name: rabbit3
     depends_on:
@@ -107,9 +113,9 @@ services:
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
       - RABBITMQ_NODENAME=${RABBITMQ_NODENAME_PREFIX}rabbit3
     volumes:
-      - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
-      - ./rabbitmq/data/rabbit3:/var/lib/rabbitmq/mnesia
-      - ./rabbitmq/definitions.json:/etc/rabbitmq/definitions.json:ro
+      - ./rabbitmq-cluster/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
+      - ./rabbitmq-cluster/data/rabbit3:/var/lib/rabbitmq/mnesia
+      - ./rabbitmq-cluster/definitions.json:/etc/rabbitmq/definitions.json:ro
     entrypoint: >
       bash -c "
         rabbitmq-server -detached &&

--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -7,6 +7,13 @@ services:
       sh -c "
         exec haproxy -f /usr/local/etc/haproxy/haproxy.cfg
       "
+    depends_on:
+      rabbit1:
+        condition: service_healthy
+      rabbit2:
+        condition: service_healthy
+      rabbit3:
+        condition: service_healthy
     tmpfs:
       - /tmp/haproxy:mode=1777,size=16m   # ← 핵심
     volumes:

--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -1,29 +1,27 @@
 global
     log stdout format raw local0
-    stats socket /var/run/haproxy.sock mode 600 level admin
+    stats socket /tmp/haproxy/haproxy.sock mode 600 level admin
 
 defaults
-    mode    tcp
+    log             global
+    mode            tcp
     timeout connect 5s
     timeout client  30s
     timeout server  30s
+    retries         2                      # 연결 실패 시 최대 2회 재시도
+    option redispatch                       # 첫 시도 실패 시 다른 서버로 재배치
+    retry-on        conn-failure empty-response response-timeout
 
-frontend amqp
-    bind *:50000-50100
+frontend amqp_global
+    bind *:5672
     mode tcp
     option tcplog
-    tcp-request inspect-delay 5s
-    tcp-request content accept if WAIT_END
-    default_backend amqp_leader
+    default_backend rabbit_cluster
 
-backend amqp_leader
-    mode tcp
-    balance static-rr
-    # 서버 ID는 map에서 나오는 이름과 일치시킵니다
-    server rabbit1 rabbit1:5672 check
-    server rabbit2 rabbit2:5672 check
-    server rabbit3 rabbit3:5672 check
-
-    # 항상 map에서 지정된 서버로만 연결
-    # map 파일 key=dst_port, value=serverID
-    use-server %[dst_port,map(/etc/haproxy/port_map.map)]
+backend rabbit_cluster
+    mode    tcp
+    balance roundrobin                     # 또는 leastconn
+    option  tcp-check
+    server  rabbit1 rabbit1:5672 check inter 1s fall 2 rise 1
+    server  rabbit2 rabbit2:5672 check inter 1s fall 2 rise 1
+    server  rabbit3 rabbit3:5672 check inter 1s fall 2 rise 1

--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -25,3 +25,24 @@ backend rabbit_cluster
     server  rabbit1 rabbit1:5672 check inter 1s fall 2 rise 1
     server  rabbit2 rabbit2:5672 check inter 1s fall 2 rise 1
     server  rabbit3 rabbit3:5672 check inter 1s fall 2 rise 1
+
+# =================================================================
+# RabbitMQ Management UI 트래픽 (포트 15672) - 신규 추가 (순차 접속)
+# =================================================================
+
+frontend rabbitmq_mgmt_ui
+    bind *:15672
+    mode http                                   # <-- 다시 http 모드로 변경!
+    default_backend rabbit_mgmt_cluster
+
+backend rabbit_mgmt_cluster
+    mode    http                                # <-- 다시 http 모드로 변경!
+    balance first
+    # Basic 인증 헤더가 포함된, 올바른 HTTP 헬스체크 사용
+    # 'guest:guest'를 Base64 인코딩한 'Z3Vlc3Q6Z3Vlc3Q=' 사용
+    option httpchk GET /api/aliveness-test/%2f HTTP/1.1\r\nHost:\ localhost\r\nAuthorization:\ Basic\ Z3Vlc3Q6Z3Vlc3Q=
+
+    # 서버 목록은 그대로
+    server  rabbit1 rabbit1:15672 check inter 1s fall 2 rise 1
+    server  rabbit2 rabbit2:15672 check inter 1s fall 2 rise 1 backup
+    server  rabbit3 rabbit3:15672 check inter 1s fall 2 rise 1 backup

--- a/logstash/pipeline1/logstash.conf
+++ b/logstash/pipeline1/logstash.conf
@@ -1,6 +1,6 @@
 input {
   rabbitmq {
-    host     => "rabbitmq"
+    host     => "haproxy"
     queue    => "logs_pipeline_1"
     durable  => true
     codec    => "json"

--- a/logstash/pipeline1/logstash.conf
+++ b/logstash/pipeline1/logstash.conf
@@ -1,6 +1,7 @@
 input {
   rabbitmq {
     host     => "haproxy"
+    heartbeat => 30
     queue    => "logs_pipeline_1"
     durable  => true
     codec    => "json"

--- a/logstash/pipeline2/logstash.conf
+++ b/logstash/pipeline2/logstash.conf
@@ -1,6 +1,7 @@
 input {
   rabbitmq {
-    host     => "rabbitmq"
+    host     => "haproxy"
+    heartbeat => 30
     queue    => "logs_pipeline_2"
     durable  => true
     codec    => "json"

--- a/logstash/pipeline3/logstash.conf
+++ b/logstash/pipeline3/logstash.conf
@@ -1,6 +1,7 @@
 input {
   rabbitmq {
-    host     => "rabbitmq"
+    host     => "haproxy"
+    heartbeat => 30
     queue    => "logs_pipeline_3"
     durable  => true
     codec    => "json"

--- a/rabbitmq-cluster/Dockerfile
+++ b/rabbitmq-cluster/Dockerfile
@@ -1,0 +1,5 @@
+# haproxy/rabbitmq/Dockerfile
+FROM rabbitmq:3.12.2-management
+
+# 플러그인 설치 (내장 플러그인이므로 enable만)
+RUN rabbitmq-plugins enable --offline rabbitmq_consistent_hash_exchange

--- a/rabbitmq-cluster/definitions.json
+++ b/rabbitmq-cluster/definitions.json
@@ -19,14 +19,15 @@
   "policies": [],
   "exchanges": [
     {
-      "name": "app_logs_exchange",
-      "type": "direct",
-      "durable": true,
-      "vhost": "/",
-      "auto_delete": false,
-      "internal": false,
-      "arguments": {}
-    },
+    "name": "app_logs_exchange",           
+    "type": "consistent_hash",        
+    "durable": true,
+    "vhost": "/",
+    "auto_delete": false,
+    "internal": false,
+    "arguments": {
+      "hash-header": "log_key"        
+    }},
     {
       "name": "worker_tasks_exchange",
       "type": "direct",
@@ -69,21 +70,24 @@
       "vhost": "/",
       "destination": "logs_pipeline_1",
       "destination_type": "queue",
-      "routing_key": "logs_1"
+      "routing_key": "1",
+      "args": {"hash-header":"log_key"}
     },
     {
       "source": "app_logs_exchange",
       "vhost": "/",
       "destination": "logs_pipeline_2",
       "destination_type": "queue",
-      "routing_key": "logs_2"
+      "routing_key": "1",
+      "args": {"hash-header":"log_key"}
     },
     {
       "source": "app_logs_exchange",
       "vhost": "/",
       "destination": "logs_pipeline_3",
       "destination_type": "queue",
-      "routing_key": "logs_3"
+      "routing_key": "1",
+      "args": {"hash-header":"log_key"}
     },
     {
       "source": "worker_tasks_exchange",

--- a/rabbitmq-cluster/definitions.json
+++ b/rabbitmq-cluster/definitions.json
@@ -24,10 +24,8 @@
     "durable": true,
     "vhost": "/",
     "auto_delete": false,
-    "internal": false,
-    "arguments": {
-      "hash-header": "log_key"        
-    }},
+    "internal": false
+    },
     {
       "name": "worker_tasks_exchange",
       "type": "direct",
@@ -70,24 +68,21 @@
       "vhost": "/",
       "destination": "logs_pipeline_1",
       "destination_type": "queue",
-      "routing_key": "1",
-      "args": {"hash-header":"log_key"}
+      "routing_key": "1"
     },
     {
       "source": "app_logs_exchange",
       "vhost": "/",
       "destination": "logs_pipeline_2",
       "destination_type": "queue",
-      "routing_key": "1",
-      "args": {"hash-header":"log_key"}
+      "routing_key": "1"
     },
     {
       "source": "app_logs_exchange",
       "vhost": "/",
       "destination": "logs_pipeline_3",
       "destination_type": "queue",
-      "routing_key": "1",
-      "args": {"hash-header":"log_key"}
+      "routing_key": "1"
     },
     {
       "source": "worker_tasks_exchange",

--- a/rabbitmq-cluster/definitions.json
+++ b/rabbitmq-cluster/definitions.json
@@ -20,7 +20,7 @@
   "exchanges": [
     {
     "name": "app_logs_exchange",           
-    "type": "consistent_hash",        
+    "type": "x-consistent-hash",        
     "durable": true,
     "vhost": "/",
     "auto_delete": false,

--- a/rabbitmq-cluster/rabbitmq.conf
+++ b/rabbitmq-cluster/rabbitmq.conf
@@ -1,3 +1,5 @@
 # RabbitMQ 기본 AMQP/HTTP 포트
 listeners.tcp.default = 5672
 management.listener.port = 15672
+queue_leader_locator = balanced
+management.load_definitions = /etc/rabbitmq/definitions.json

--- a/rabbitmq-cluster/rabbitmq.conf
+++ b/rabbitmq-cluster/rabbitmq.conf
@@ -2,4 +2,4 @@
 listeners.tcp.default = 5672
 management.listener.port = 15672
 queue_leader_locator = balanced
-management.load_definitions = /etc/rabbitmq/definitions.json
+# management.load_definitions = /etc/rabbitmq/definitions.json


### PR DESCRIPTION
## 관련 이슈
- [RabbitMQ 클러스터 아키텍처 #2](https://github.com/Log-Central/log-central-be/issues/2)

## 변경 사항
### Docker-compose-ha 파일 설정
- Temporary file system을 이용한 socket 파일 권한 문제 우회
  - 권한 문제를 회피하기 위해 docker-compose tmpfs를 이용하여 메모리에 소켓 파일을 로드하고, 유저 권한에 관계없이 접근할 수 있도록 수정함.
  - 소켓 파일은 디스크 생성 시 임시로 생성되므로 디스크 volume을 굳이 사용할 필요가 없다고 판단함.
- 클러스터 생성 시 definition.json 적용 설정
  - 기존에 rabbit1 ~ rabbit3 컨테이너에서 definition.json 파일을 초기에 마운트하여 해당 설정이 미리 적용되는 현상이 발생하여, definition.json의 적용이 rabbit-final 컨테이너에서만 이뤄지도록 하기 위해 볼륨 마운트 삭제
  - rabbit-final 컨테이너에서 모든 노드의 클러스터 join을 명시적으로 기다리도록 하고, join 이후 60초의 대기 시간을 두어 모든 설정이 충분히 동기화되어 definition.json이 문제 없이 적용될 수 있도록 변경
### HAProxy 설정
- rabbitmq 접근에 haproxy를 반드시 거치도록 변경
  - 각 노드의 5672, 15672번 포트에 접근할 때 노드가 avaliable하지 않을 경우 요청이 유실되는 문제를 해결하기 위해 rabbitmq를 리버스 프록시를 이용하여 접근하도록 변경
  - 5672번 포트의 경우 각 메시지를 round-robin 방식을 써서 available한 노드에 균등하게 전송
  - 15672번 포트의 경우 rabbit1이 avaliable하면 rabbit1로 요청 전송, 그렇지 않은 경우 rabbit2 > rabbit3 우선순위대로 전송
### RabbitMQ 클러스터 설정
- Exchange 설정 변경
  - Exchange를 consistent-hash 방식으로 변경, 일정한 hash 값을 routing key로 하여 각 큐로 메시지를 균등 분배함.
  - definition.json 내 라우팅 키 설정은 일반적으로 routing key로 활용되나, consistent-hash 방식의 경우 hash 공간의 크기를 결정한다. 즉 이 키를 같게 할 경우 hash 공간의 크기가 똑같아져 각 큐에 균등하게 메시지가 분배되도록 할 수 있다.
  - Dockerfile을 추가로 두어 파일에서 직접 consistent-hash 방식 exchange 사용을 위한 플러그인을 설치하도록 함.